### PR TITLE
#162314530 As a developer, I should see the status of the last completed task in a client's work plan set to "COMPLETED" when the client replies to the bot that the task has been completed.

### DIFF
--- a/scripts/ultimatedone.rive
+++ b/scripts/ultimatedone.rive
@@ -3,5 +3,8 @@
   - ^image("<get celebrationImgUrl>")<send>
   ^ WOW! This. Is. Major. You've finished every task in your work plan, <get username>!
   ^ \n\nTake a moment. You should feel INCREDIBLY proud of each and every step you've taken on this journey so far!
-  ^ \n\nNow might be a good time to check in with <get coachName> at <get orgName> on your progress. 
+  ^ \n\nNow might be a good time to check in with <get coachName> at <get orgName> on your progress.
+  ^ {@ setvars}
+  + setvars
+  - <set taskComplete=true>
 < topic


### PR DESCRIPTION
#### What does this PR do?
Set the status of the last completed task on a client's workplan to `COMPLETE` when the client replies to the ROO bot that the task has been completed

#### Description of Task to be completed?
- Set the status of the last completed task to COMPLETE

#### How should this be manually tested?
- $ git clone https://github.com/IDEOorg/steps-bot.git
- $ cd steps-bot
- $ npm install
- $ npm start
- on the roo app, create a client and create two tasks on their workplan
- from the (twiliogui)[http://twilio-gui.herokuapp.com] app reply to the bot that both tasks are complete.

#### Any background context you want to provide?
Given a user is on the last task on his/her workplan, when the user replies to the bot that they have completed said task, the status of the said task did not update to `COMPLETE`.

#### What are the relevant pivotal tracker stories?
[#162314530](https://www.pivotaltracker.com/n/projects/2204131/stories/162314530)
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A