### PR TITLE
#163277110 As a client, I should continue to receive check-ins from Roo after it checks in with the first action item, when I have only one task(first ever task) in my work plan

### DIFF
--- a/scripts/introtask.rive
+++ b/scripts/introtask.rive
@@ -7,6 +7,7 @@
   ^ <sms>\n\nIf you need some assistance, text the letter "A". If you've finished, text the letter "B".<send></sms>
   ^ \n\nSelect a button below! Or, you can text "PLAN" to see your full work plan, or "STOP" to stop receiving messages from me.
   ^ <fb>^template(`quickreply`, `Need some assistance`, `Still working`, `I'm done`)<send></fb>
+  ^ {@ setvars}
   + (a|need some assistance)
   - {topic=help}{@ startprompt}
   + (b|im done)

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -726,7 +726,7 @@ test('user is scheduled to receive their very first task (introtask topic)', asy
   });
   await u.loadNewInfoToClient();
   expect(chatbot.client.topic).toEqual('introtask');
-  expect(chatbot.client.checkin_times[0].topic).toEqual('help');
+  expect(chatbot.client.checkin_times[0].topic).toEqual('content');
 });
 
 test('user is scheduled to receive a task besides the first task (nexttask topic)', async () => {


### PR DESCRIPTION
#### What does this PR do?
Ensures that a client continues to receive check-ins from Roo if he or she has just one task(first ever task) on his/her work plan, and has received the `first action item` check-in from the Roo bot.

#### Description of Task to be completed?
- update introtask.rive to set Rivebot variables

#### How should this be manually tested?
- Log in as a coach and create a client if not already present
- Add a single task to the client's work plan
- Initiate the conversation with the bot by sending `start`, then send `ff` till you get a message about `first action item`.
- Send ff again, you should receive a content(motivational article)

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#163277110

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A
