### PR TITLE
#163722711 Roo-bot should only auto checkin on clients in produ…

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ BOT_ID=116
 SENDGRID_API_KEY=
 PM_EMAIL=
 ADMIN_URL=
+NODE_ENV=
 ```
 
 You'll need a Twilio account to provide the `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_NUMBER` credentials for SMS. [Follow these instructions in the slides to get set up with Twilio](https://docs.google.com/presentation/d/1TDnPto_Cl4piWOrG6cf-_XmdVNg-Aqdwp1QLzIyLqos/edit?usp=sharing) (see the Twilio Config section of the slides).

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,0 +1,7 @@
+const isProductionEnvironment = () => (process.env.NODE_ENV === 'production');
+const isStagingEnvironment = () => (process.env.NODE_ENV === 'staging');
+
+module.exports = {
+  isProductionEnvironment,
+  isStagingEnvironment
+};

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ require('dotenv').config();
 const api = require('./src/api');
 const Botkit = require('botkit');
 const server = require('./server.js');
+const helpers = require('./helpers');
 
 // Create the Botkit controller, which controls all instances of the bot.
 const twilioController = Botkit.twiliosmsbot({
@@ -18,9 +19,11 @@ const twilioController = Botkit.twiliosmsbot({
 // Set up an Express-powered webserver to webhook endpoints
 server(fbEndpoint, twilioController, getCoachResponse);
 
-setInterval(() => {
-  messageAllClientsWithOverdueCheckinsOrFollowups();
-}, 5400000); // 5400000 check all clients for checkin messages every 90 minutes
+if (helpers.isProductionEnvironment()) {
+  setInterval(() => {
+    messageAllClientsWithOverdueCheckinsOrFollowups();
+  }, 5400000); // 5400000 check all clients for checkin messages every 90 minutes
+}
 
 // takes in the request FB sends and formats that data and passes it into the run() function.
 async function fbEndpoint(req, res) {

--- a/src/Rivebot.js
+++ b/src/Rivebot.js
@@ -3,6 +3,7 @@ const constants = require('./constants');
 const assetUrls = require('./assets-manifest.json');
 const path = require('path');
 const RiveScript = require('rivescript');
+const helpers = require('../helpers');
 
 const { TOPICS } = constants;
 
@@ -377,7 +378,7 @@ function formatReferralLinkForNewFBSignups(userPlatformId) {
       // cannot rely on process.env.NODE_ENV because both staging and prod run
       // as 'production' when deployed. Set env var to true for staging deployment.
       // false for production.
-      const refLink = process.env.STAGING === 'false'
+      const refLink = !helpers.isStagingEnvironment()
         ? process.env.FB_REFERRAL_LINK
         : process.env.FB_REFERRAL_LINK_STAGING;
       const referralId = userPlatformId.slice(2);


### PR DESCRIPTION
#### What does this PR do?

This PR ensures that autocheckins are only performed on clients in the production environment

#### Description of Task to be completed?

- Find code that performs autocheckin
- Add a check to ensure it does so only in production

#### How should this be manually tested?

N/A

#### Any background context you want to provide?

Initially, if a developer is working with the production database locally, the actual clients would get checkins, which shouldn't be the case

#### What are the relevant pivotal tracker stories?

[#163722711](https://www.pivotaltracker.com/story/show/163722711)

#### Screenshots (if appropriate)

N/A

#### Questions:

N/A