### PR TITLE
#164212779 Fix Broken Image URLs

### DIFF
--- a/src/Messenger.js
+++ b/src/Messenger.js
@@ -78,7 +78,7 @@ module.exports = class Messenger {
         if (message.type === 'text') { // eslint-disable-line
           messageToUpload = message.message;
         } else if (message.type === 'image') {
-          messageToUpload = message.message + '\n' + message.image;
+          messageToUpload = message.image;
         }
       }
       api.createMessage(null, process.env.BOT_ID, this.client.id, messageToUpload, this.client.topic);
@@ -182,7 +182,6 @@ function formatMsgForSMS(message) {
     };
   } else if (type === 'image') {
     return {
-      body: message.message,
       mediaUrl: message.image
     };
   }


### PR DESCRIPTION
### What does this PR do?
Currently, the BOT adds `undefined` to all image URLs in the database. This makes it difficult to render the images correctly on the frontend.

This PR fixes that.

### Description of tasks to be completed
- stop the bot from adding undefined to image URL

### How should this be manually tested?
* Clone this repo
* Checkout to a branch `bg-fix-broken-chat-image-urls-164212779`.
* Run `npm start` and `npm run start:live:dev`
* Setup Twilio webhook.
* Log in as a coach and create a client if not already present.
* Add a task to the client's work plan and mark the task as completed.
* Visit [twilio-gui](http://twilio-gui.herokuapp.com) and get a phone number.
* login to `twilio-gui`
* Initiate the conversation with the bot by sending `hi`.
* Fast forward the conversation by sending `ff`.
* Check the database table `messages` and notice that the `ultimatedone` image does not have `undefined` in the URL.

### What are the relevant pivotal tracker stories?
[#164212779](https://www.pivotaltracker.com/story/show/164212779)

### Any Background Context
N/A

### Screenshots?
N/A

### Questions
N/A
