### PR TITLE
#164385444 Ensure inactive users do not receive messages from Roo

### DIFF
--- a/helpers/index.js
+++ b/helpers/index.js
@@ -1,7 +1,9 @@
 const isProductionEnvironment = () => (process.env.NODE_ENV === 'production');
 const isStagingEnvironment = () => (process.env.NODE_ENV === 'staging');
+const isActive = user => user.active;
 
 module.exports = {
   isProductionEnvironment,
-  isStagingEnvironment
+  isStagingEnvironment,
+  isActive
 };

--- a/src/Chatbot.js
+++ b/src/Chatbot.js
@@ -119,6 +119,7 @@ module.exports = class Chatbot {
     const chatURL = userInfo ? await api.getChatURLfromPlanURL(userInfo.plan_url) : null;
     this.chatURL = chatURL;
     this.client = userInfo;
+    return this.client;
   }
 
   setUnrecognizedClientResponse() {


### PR DESCRIPTION
#### What does this PR do?

This PR ensures that no messages are sent by the bot to inactive users

#### Description of Task to be completed

When a client's active field is set to `false`, then the user should not receive followups or checkins, also when s/he tries to interact with the bot, for example sending `A` or `B`, they don't get a reply

#### How should this be manually tested?

- Clone this repo
- Login onto twilio GUI with the relevant phone number
- Change client's active field on the user table in the database from `true` to `false`.   
- Send `A` or `B`

#### Any background context you want to provide?

Initially, there was no active field on the user table and therefore it wasn't necessary to ensure that only active users can interact with the bot

#### What are the relevant pivotal tracker stories?

[#164385444](https://www.pivotaltracker.com/story/show/164385444)

#### Screenshots (if appropriate)

N/A

#### Checklist

- [x] My code follows the style guidelines of this project
- [ ] At least 2 people have reviewed this PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I don't have more than 3 major commits on this PR