### PR TITLE
#165092056 As a client, I should be able to chat with my coach using a link from Roo

### DIFF
--- a/scripts/help.rive
+++ b/scripts/help.rive
@@ -1,7 +1,6 @@
 > topic help includes global includes tempfastforward includes gibberish
   + startprompt
-  - Great, I'm here to help. Please tell me (with as many details as possible)\s
-  ^ what you need assistance with so I can contact Coach <get coachName> and get some answers.
+  - Okay, <get username>. To talk to your coach, please visit this link and send them a message: <get chatLink>. When your coach responds, I'll let you know.
   ^ {topic=helpuserresponse}<set hours=8><set nextTopic=help><set nextMessage=pinguser>
   + pinguser
   - I haven't heard back from you in a while about the help you requested.

--- a/src/Messenger.js
+++ b/src/Messenger.js
@@ -12,7 +12,7 @@ module.exports = class Messenger {
     this.isMessageSentFromCheckIn = opts.isMessageSentFromCheckIn;
     this.client = opts.client;
   }
-
+  
   // sends the message to the Facebook or SMS platform
   async sendReply() {
     if (this.messages === null) {

--- a/src/Rivebot.js
+++ b/src/Rivebot.js
@@ -96,6 +96,11 @@ module.exports = class Rivebot {
     );
     await this.rivebot.setUservar(
       userPlatformId,
+      'chatLink',
+      client.chat_url
+    );
+    await this.rivebot.setUservar(
+      userPlatformId,
       'introVideoLink',
       constants.INTRO_VIDEO_URL
     );


### PR DESCRIPTION
#### What does this PR do?
This PR allows the client to chat with a coach directly after clicking on the magic link sent by the bot (after the client texts "coach")
#### Description of Task to be completed
- Restructure help request flow
- Creates a chat view for the client
#### How should this be manually tested?
- `git checkout ft-client-coach-roo-web-chat-165092056`
- npm start
- Start the bot 
- Send the keyword "coach"
- Click the link using another browser ( you ought to be redirected to client's views)
- Login as a coach
- Click on `view clients` in the coach profile page
- Click on any client's profile and head to the chat view
- Send a text
- Go back to the client app and refresh. You should see the message the coach sent
#### Any background context you want to provide?
n the new flow, we remove Roo as the middle man and direct the client to an online chat interface where they can exchange messages directly with their coach. Roo just provides the link to that interface.
#### What are the relevant pivotal tracker stories?
[#165092056](https://www.pivotaltracker.com/story/show/165092056)
#### Screenshots (if appropriate)
![roo](https://user-images.githubusercontent.com/16904946/56644566-9f8c5080-6684-11e9-8a22-f55c63d6fb98.gif)


#### Checklist

- [x] My code follows the style guidelines of this project
- [ ] At least 2 people have reviewed this PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I don't have more than 3 major commits on this PR