### PR TITLE
#165674636 Prevent Memory Overshoot on Heroku

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6326,6 +6326,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -8665,6 +8670,14 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
+    },
+    "throng": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/throng/-/throng-4.0.0.tgz",
+      "integrity": "sha1-mDxroZk7WOroWZmKpof/6I34TBc=",
+      "requires": {
+        "lodash.defaults": "^4.0.1"
+      }
     },
     "through": {
       "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "request-promise": "^4.2.2",
     "rivescript": "^2.0.0-alpha.6",
     "swagger-ui-express": "^4.0.2",
+    "throng": "^4.0.0",
     "twilio": "^3.17.2",
     "yamljs": "^0.3.0"
   },

--- a/server.js
+++ b/server.js
@@ -60,13 +60,15 @@ module.exports = function server(
   testTwilioCredentials
 ) {
   const app = express();
+  const PORT = process.env.PORT || 3002;
+
   app.use(cors());
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use('/static', express.static(path.join(__dirname, 'static')));
   app.use('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerDocument));
-  app.listen(process.env.PORT || 3002, null, () => {
-    console.log(`listening on server port ${process.env.PORT || 3002}`);
+  app.listen(PORT, null, () => {
+    console.log(`listening on server port ${PORT}`);
   });
 
   // sets up webhook routes for Twilio and Facebook

--- a/server.js
+++ b/server.js
@@ -65,7 +65,9 @@ module.exports = function server(
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use('/static', express.static(path.join(__dirname, 'static')));
   app.use('/api-docs', swaggerUI.serve, swaggerUI.setup(swaggerDocument));
-  app.listen(process.env.PORT || 3002, null, () => { });
+  app.listen(process.env.PORT || 3002, null, () => {
+    console.log(`listening on server port ${process.env.PORT || 3002}`);
+  });
 
   // sets up webhook routes for Twilio and Facebook
   routes(app, fbEndpoint, twilioReceiveSmsController, getCoachResponse, testTwilioCredentials);


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue where the number of workers spawned on Heroku caused the bot to use more memory than is available crashing the app.

#### Description of Task to be completed
- update number of workers to be spawned
- use throng for worker monitoring

#### How should this be manually tested?
- Checkout to this branch.
- Add a new entry in your `.env` file called `WEB_CONCURRENCY` and set it to a number less than the number of cores in your local setup.
- Run `npm start` and observe that the number of `listening` logs on the console corresponds to the value of `process.env.WEB_CONCURRENCY`.

#### Any background context you want to provide?
The number of workers that will be spawned in Heroku will be dynamically calculated by Heroku for the optimal performance.

On localhost, the number of workers that will be spawned will be determined by an `env` variable `WEB_CONCURRENCY`;

#### What are the relevant pivotal tracker stories?
[#165674636](https://www.pivotaltracker.com/story/show/165674636)

#### Screenshots (if appropriate)
N/A

#### Checklist

- [x] My code follows the style guidelines of this project
- [x] At least 2 people have reviewed this PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I don't have more than 3 major commits on this PR
