### PR TITLE
#165853294 Fix chat_url undefined

### DIFF
--- a/src/Rivebot.js
+++ b/src/Rivebot.js
@@ -94,10 +94,11 @@ module.exports = class Rivebot {
       'workplanLink',
       client.plan_url
     );
+    const chatUrl = client.plan_url.replace('plan', 'clientChat');
     await this.rivebot.setUservar(
       userPlatformId,
       'chatLink',
-      client.chat_url
+      chatUrl
     );
     await this.rivebot.setUservar(
       userPlatformId,


### PR DESCRIPTION
#### What does this PR do?
Modifies the chatLink variable by getting the plan_url from db and replacing 'plan' with 'clientChat'
#### Description of Task to be completed
Retrieve plan_url string from db and use string replace() method to get a chatLink
#### How should this be manually tested?
- `git checkout bg-fix-chaturl-variable-undefined-165853294`
- npm start
- Start the bot 
- Send the keyword "coach"
- Click the link using another browser ( you ought to be redirected to client's views)
#### Any background context you want to provide?
ChatLink was undefined for already existing clients.
#### What are the relevant pivotal tracker stories?
[#165853294](https://www.pivotaltracker.com/story/show/165853294)
#### Screenshots (if appropriate)
<img width="1409" alt="Screenshot 2019-05-09 at 11 43 01" src="https://user-images.githubusercontent.com/16904946/57439910-ace23700-724f-11e9-900d-98ee3239ef87.png">

#### Checklist

- [x] My code follows the style guidelines of this project
- [ ] At least 2 people have reviewed this PR
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I don't have more than 3 major commits on this PR
